### PR TITLE
Fix `Sort Artboards by Position` with globally scoped doc variable

### DIFF
--- a/Sketch Mate.sketchplugin/Contents/Sketch/Artboards/Sort Artboards by Position.js
+++ b/Sketch Mate.sketchplugin/Contents/Sketch/Artboards/Sort Artboards by Position.js
@@ -14,13 +14,14 @@ function sortLeft(a,b) {
 }
 
 
-
+var doc;
+var selection;
 
 var onRun = function (context) {
 
     // old school variable
-    var doc = context.document;
-    var selection = context.selection;
+    doc = context.document;
+    selection = context.selection;
 
     // at least two artboards need to be selected
     if (selection.count() > 1 && selection[0].className() == "MSArtboardGroup") {


### PR DESCRIPTION
This fixes issue #16  
