### PR TITLE
Fix "Duplicate Artboard"

### DIFF
--- a/Sketch Mate.sketchplugin/Contents/Sketch/Artboards/Duplicate Artboard.js
+++ b/Sketch Mate.sketchplugin/Contents/Sketch/Artboards/Duplicate Artboard.js
@@ -37,7 +37,7 @@ var onRun = function (context) {
         }
 
     }
-    var action = doc.actionsController().actionWithName("MSCanvasActions");
+    var action = doc.actionsController().actionWithID("MSCanvasActions");
     action.duplicate(nil);
 
 }


### PR DESCRIPTION
Fixes issue 24: https://github.com/getflourish/Sketch-Mate/issues/24

This was due to changes in Sketch "MSActionController"

I use this everyday of my life, so I couldn't let it go. :)
