### PR TITLE
Fix for "Select Below" for Sketch 46

### DIFF
--- a/Sketch Mate.sketchplugin/Contents/Sketch/Select/Select Below.js
+++ b/Sketch Mate.sketchplugin/Contents/Sketch/Select/Select Below.js
@@ -19,11 +19,11 @@ var onRun = function(context) {
   // code below contains code from Ashung Hung, Ashung.hung@gmail.com
 
   // Deselect all layers
-  if (page.deselectAllLayers) {
-      page.deselectAllLayers();
-  } else {
-      page.changeSelectionBySelectingLayers(nil);
-  }
+  // if (page.deselectAllLayers) {
+  //     page.deselectAllLayers();
+  // } else {
+  //     page.changeSelectionBySelectingLayers(nil);
+  // }
 
   var loop = queryResult.objectEnumerator();
   var layer;

--- a/Sketch Mate.sketchplugin/Contents/Sketch/Select/Select Below.js
+++ b/Sketch Mate.sketchplugin/Contents/Sketch/Select/Select Below.js
@@ -4,9 +4,10 @@ var onRun = function(context) {
 
   var doc = context.document;
   var selection = context.selection[0];
+  var page = doc.currentPage();
 
   // set the scope to the layer group that the currently selected layer is in
-  var scope = selection.parentGroup().layers().array();
+  var scope = selection.parentGroup().layers();
 
   // calculate the bottom position of the selected layer
   var bottom = selection.absoluteRect().y() + selection.absoluteRect().height();
@@ -15,6 +16,25 @@ var onRun = function(context) {
   var predicate = NSPredicate.predicateWithFormat("absoluteRect.y >= %@", bottom);
   var queryResult = scope.filteredArrayUsingPredicate(predicate);
 
-  // select all layers that match the query
-  doc.currentPage().selectLayers(queryResult);
+  // code below contains code from Ashung Hung, Ashung.hung@gmail.com
+
+  // Deselect all layers
+  if (page.deselectAllLayers) {
+      page.deselectAllLayers();
+  } else {
+      page.changeSelectionBySelectingLayers(nil);
+  }
+
+  var loop = queryResult.objectEnumerator();
+  var layer;
+  while (layer = loop.nextObject()) {
+      if (layer.parentGroup().class() != "MSPage") {
+          // Fix Sketch 45
+          if (MSApplicationMetadata.metadata().appVersion < 45) {
+              layer.select_byExpandingSelection(true, true);
+          } else {
+              layer.select_byExtendingSelection(true, true);
+          }
+      }
+  }
 };

--- a/Sketch Mate.sketchplugin/Contents/Sketch/Smart Align/Smart Align Bottom.js
+++ b/Sketch Mate.sketchplugin/Contents/Sketch/Smart Align/Smart Align Bottom.js
@@ -28,12 +28,28 @@ var onRun = function (context) {
     	// get the parents left position
     	var edge = layer.parentGroup().absoluteRect().y() + layer.parentGroup().absoluteRect().height();
 
-    	// align layer with parent
-    	if (bottom != edge) {
-    		layer.absoluteRect().setY(edge - height);
-    	} else {
-    		com.getflourish.utils.sendAlignBottom();
-    	}
+      // set the scope to the layer group that the currently selected layer is in
+      var scope = layer.parentGroup().layers();
+      // set up the predicate and receive an array of matched layers
+      var predicate = NSPredicate.predicateWithFormat("absoluteRect.y > %@", bottom);
+      var queryResult = scope.filteredArrayUsingPredicate(predicate);
+
+      // find topmost layer (queryResult seems not to be sortable)
+      var loop = queryResult.objectEnumerator();
+      var item, topmost = Number.MAX_VALUE;
+      while (item = loop.nextObject()) {
+        var top = item.absoluteRect().y() - height;
+        if (top < topmost) {topmost = top}
+      }
+
+      // position layer
+      if (topmost != Number.MAX_VALUE) {
+        layer.absoluteRect().setY(topmost);
+      } else if (bottom < edge) {
+        layer.absoluteRect().setY(edge - height);
+      } else {
+        com.getflourish.utils.sendAlignBottom();
+      }
 
     	// display relative position info
     	com.getflourish.common.showMarginsOf(layer);

--- a/Sketch Mate.sketchplugin/Contents/Sketch/Smart Align/Smart Align Left.js
+++ b/Sketch Mate.sketchplugin/Contents/Sketch/Smart Align/Smart Align Left.js
@@ -28,14 +28,28 @@ var onRun = function (context) {
         // get parent absolute x
         var parentX = layer.parentGroup().absoluteRect().x();
 
-        // align layer with parent
-        if (left != parentX) {
-            layer.absoluteRect().setX(parentX);
+        // set the scope to the layer group that the currently selected layer is in
+        var scope = layer.parentGroup().layers();
+        // set up the predicate and receive an array of matched layers
+        var predicate = NSPredicate.predicateWithFormat("absoluteRect.x+absoluteRect.width < %@", left);
+        var queryResult = scope.filteredArrayUsingPredicate(predicate);
+
+        // find rightmost layer (queryResult seems not to be sortable)
+        var loop = queryResult.objectEnumerator();
+        var item, rightmost = -Number.MAX_VALUE;
+        while (item = loop.nextObject()) {
+          var right = item.absoluteRect().x() + item.absoluteRect().width()
+          if (right > rightmost) {rightmost = right}
+        }
+        // move layer
+        if (rightmost != -Number.MAX_VALUE) {
+          layer.absoluteRect().setX(rightmost);
+        } else if (left > parentX) {
+          layer.absoluteRect().setX(parentX);
         } else {
-            com.getflourish.utils.sendAlignLeft();
+          com.getflourish.utils.sendAlignLeft();
         }
 
-        // display relative position info
         com.getflourish.common.showMarginsOf(layer);
     } else {
         com.getflourish.utils.sendAlignLeft();

--- a/Sketch Mate.sketchplugin/Contents/Sketch/Smart Align/Smart Align Right.js
+++ b/Sketch Mate.sketchplugin/Contents/Sketch/Smart Align/Smart Align Right.js
@@ -28,11 +28,27 @@ var onRun = function (context) {
         // get the parents left position
         var edge = layer.parentGroup().absoluteRect().x() + layer.parentGroup().absoluteRect().width();
 
-        // align layer with parent
-        if (right != edge) {
-            layer.absoluteRect().setX(edge - width);
+        // set the scope to the layer group that the currently selected layer is in
+        var scope = layer.parentGroup().layers();
+        // set up the predicate and receive an array of matched layers
+        var predicate = NSPredicate.predicateWithFormat("absoluteRect.x > %@", right);
+        var queryResult = scope.filteredArrayUsingPredicate(predicate);
+
+        // find leftmost layer (queryResult seems not to be sortable)
+        var loop = queryResult.objectEnumerator();
+        var item, leftmost = Number.MAX_VALUE;
+        while (item = loop.nextObject()) {
+          var left = item.absoluteRect().x() - width;
+          if (left < leftmost) {leftmost = left}
+        }
+
+        // position layer
+        if (leftmost != Number.MAX_VALUE) {
+            layer.absoluteRect().setX(leftmost);
+        } else if (right < edge) {
+          layer.absoluteRect().setX(edge - width);
         } else {
-            com.getflourish.utils.sendAlignRight();
+          com.getflourish.utils.sendAlignRight();
         }
 
         // display relative position info

--- a/Sketch Mate.sketchplugin/Contents/Sketch/Smart Align/Smart Align Top.js
+++ b/Sketch Mate.sketchplugin/Contents/Sketch/Smart Align/Smart Align Top.js
@@ -28,11 +28,28 @@ var onRun = function (context) {
         // get parent absolute y
         var parentY = layer.parentGroup().absoluteRect().y();
 
-        // align layer with parent
-        if (top != parentY) {
-            layer.absoluteRect().setY(parentY);
+        // set the scope to the layer group that the currently selected layer is in
+        var scope = layer.parentGroup().layers();
+
+        // set up the predicate and receive an array of matched layers
+        var predicate = NSPredicate.predicateWithFormat("absoluteRect.y+absoluteRect.height < %@", top);
+        var queryResult = scope.filteredArrayUsingPredicate(predicate);
+
+        // find bottommost layer (queryResult seems not to be sortable)
+        var loop = queryResult.objectEnumerator();
+        var item, bottommost = -Number.MAX_VALUE;
+        while (item = loop.nextObject()) {
+          var bottom = item.absoluteRect().y() + item.absoluteRect().height()
+          if (bottom > bottommost) {bottommost = bottom}
+        }
+
+        // position layer
+        if (bottommost != -Number.MAX_VALUE) {
+          layer.absoluteRect().setY(bottommost);
+        } else if (top > parentY) {
+          layer.absoluteRect().setY(parentY);
         } else {
-            com.getflourish.utils.sendAlignTop();
+          com.getflourish.utils.sendAlignTop();
         }
 
         // display relative position info

--- a/Sketch Mate.sketchplugin/Contents/Sketch/manifest.json
+++ b/Sketch Mate.sketchplugin/Contents/Sketch/manifest.json
@@ -101,7 +101,7 @@
     {
       "name": "Select Below",
       "identifier": "com.getflourish.mate.select.below",
-      "shortcut": "shift cmd b",
+      "shortcut": "control cmd b",
       "script": "Select/Select Below.js"
     },
     {


### PR DESCRIPTION
Since "Select Below" doesn't work anymore and I find it a very useful function, I tried to find a solution.  Turns out that "selectLayers()" seems not to exist anymore. I have to admit that my fix contains some code from Ashung Hung (Ashung.hung@gmail.com) for selecting an array of layers, although this may be quite basic stuff.